### PR TITLE
Fixes the issue where env is overwritten

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -27,7 +27,7 @@ class CLanguageClient extends AutoLanguageClient {
     if (process.platform == 'win32') cmd += '.exe';
 
     console.log(`Starting server ${cmd} in project ${projectPath}.`);
-    return cp.spawn(cmd, [], { env: projectPath });
+    return cp.spawn(cmd, [], { cwd: projectPath });
   }
 }
 


### PR DESCRIPTION
When the language server is first spawned, `projectPath` is passed in as the `env` parameter. However, the `env` parameter is supposed to be an `Object` containing the key-value pairs of all environment variables (https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options). In my particular case, passing in `projectPath` as `env` would overwrite the entire environment, and would cause `PATH` to be incorrect. 

I wonder if `projectPath` is meant to be passed in as `cwd` instead? I did the following change and it started to work.