### PR TITLE
Add support for .cxx files.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,7 +4,7 @@ const OS = require('os');
 const path = require('path');
 
 class CLanguageClient extends AutoLanguageClient {
-  getGrammarScopes () { return [ 'source.c', 'source.cpp' ] }
+  getGrammarScopes () { return [ 'source.c', 'source.cpp', 'source.cxx' ] }
   getLanguageName () { return 'C / C++' }
   getServerName () { return atom.config.get("ide-c-cpp.languageServerCmd") }
 


### PR DESCRIPTION
`.cxx` is a (probably) less common extension for files containing C++ code.
Since I’m working on a project that uses this extension, the change would be really helpful.